### PR TITLE
Fix https-invalid landing page URL link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The Zigbee Alliance officially opened the Project Connected Home over IP
 (Project CHIP) Working Group on January 17, 2020 and is in the process of
 drafting the specification.
 
-Visit [connectedhomeip.com](https://connectedhomeip.com) to learn more and read
+Visit [buildwithmatter.com](https://buildwithmatter.com) to learn more and read
 the latest news and updates about the project.
 
 # Project Overview


### PR DESCRIPTION
 #### Problem
User currently faces a Browser Security warning blockage (https), when opening the project's landing page link on the README.

 #### Summary of Changes
Using directly the new URL https://buildwithmatter.com/ instead of the current problematic URL redirection.
